### PR TITLE
bug fixed: Deleting pre-orders no longer works #94

### DIFF
--- a/navbars/circulation.php
+++ b/navbars/circulation.php
@@ -37,12 +37,14 @@ if (isset($_SESSION["lastName"])) {
 <?php   
 
 if (OBIB_MBR_ACCOUNT_ONLINE == 1) {
-    if ($mbr->getPwd() == "") {
-        echo '&nbsp; &nbsp; <a href="../circ/mbr_pwd_reset_form.php?mbrid=' . HURL($mbrid) 
-           . '" class="alt1">' . $navloc->getText("PwdCreate") . '</a><br>';
-    } else {
-        echo '&nbsp; &nbsp; <a href="../circ/mbr_pwd_reset_form.php?mbrid=' . HURL($mbrid) 
-           . '" class="alt1">' . $navloc->getText("PwdReset") . '</a><br>';
+    if(isset($mbr)) {
+        if ($mbr->getPwd() == "") {
+            echo '&nbsp; &nbsp; <a href="../circ/mbr_pwd_reset_form.php?mbrid=' . HURL($mbrid) 
+               . '" class="alt1">' . $navloc->getText("PwdCreate") . '</a><br>';
+        } else {
+            echo '&nbsp; &nbsp; <a href="../circ/mbr_pwd_reset_form.php?mbrid=' . HURL($mbrid) 
+               . '" class="alt1">' . $navloc->getText("PwdReset") . '</a><br>';
+        }
     }
 }
 ?> 


### PR DESCRIPTION
Works now, but on the page shared/hold_del_confirm.php there is no link for change/create password anymore. If you wanted to do this, you would have to either,
- standardize the link name to “Edit password” or
- start another member query on the hold_del_confirm.php.