### PR TITLE
Add media type selection landing page before new catalog record form

### DIFF
--- a/catalog/biblio_new.php
+++ b/catalog/biblio_new.php
@@ -13,7 +13,11 @@ $loc = new Localize(OBIB_LOCALE,$tab);
 
 if (!isset($_REQUEST['posted'])) {
   require_once("../shared/logincheck.php");
-  showForm(array('opacFlg'=>'CHECKED'));
+  $initVars = array('opacFlg'=>'CHECKED');
+  if (isset($_GET['materialCd'])) {
+    $initVars['materialCd'] = $_GET['materialCd'];
+  }
+  showForm($initVars);
 } else {
   $postVars = $_POST;
   if ($_REQUEST['posted'] == 'media_change') {

--- a/catalog/biblio_type_select.php
+++ b/catalog/biblio_type_select.php
@@ -1,0 +1,57 @@
+<?php
+/*
+ * This file is part of a copyrighted work; it is distributed with NO WARRANTY.
+ * See the file COPYRIGHT.html for more details.
+ */
+require_once("../shared/common.php");
+$tab = "cataloging";
+$nav = "new";
+
+require_once("../shared/logincheck.php");
+require_once("../classes/DmQuery.php");
+require_once("../classes/Localize.php");
+$loc = new Localize(OBIB_LOCALE, $tab);
+
+$dmQ = new DmQuery();
+$dmQ->connect_e();
+$types = $dmQ->get("material_type_dm");
+$dmQ->close();
+
+include("../shared/header.php");
+?>
+
+<div class="container-fluid mt-3">
+  <h4><?php echo $loc->getText("biblioTypeSelectHeading"); ?></h4>
+  <div class="row mt-3">
+<?php foreach ($types as $type): ?>
+    <div class="col-6 col-sm-4 col-md-3 col-lg-2 mb-3">
+      <a href="../catalog/biblio_new.php?materialCd=<?php echo U($type->getCode()); ?>"
+         class="text-decoration-none">
+        <div class="card h-100 text-center shadow-sm biblio-type-card">
+          <div class="card-body d-flex flex-column align-items-center justify-content-center">
+            <img src="../images/<?php echo H($type->getImageFile()); ?>"
+                 alt="<?php echo H($type->getDescription()); ?>"
+                 style="max-height:48px; max-width:48px; margin-bottom:.5rem;">
+            <div class="font-weight-bold"><?php echo H($type->getDescription()); ?></div>
+          </div>
+        </div>
+      </a>
+    </div>
+<?php endforeach; ?>
+  </div>
+</div>
+
+<style>
+  .biblio-type-card {
+    cursor: pointer;
+    transition: transform .1s, box-shadow .1s;
+    border: 2px solid transparent;
+  }
+  .biblio-type-card:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 .5rem 1rem rgba(0,0,0,.15) !important;
+    border-color: #007bff;
+  }
+</style>
+
+<?php include("../shared/footer.php"); ?>

--- a/locale/de/cataloging.php
+++ b/locale/de/cataloging.php
@@ -76,6 +76,7 @@ $trans["PictDesc"]                 = "\$text = 'Die Bilddatei muß sich im Verze
 #****************************************************************************
 #*  Translation text for page biblio_new.php
 #****************************************************************************
+$trans["biblioTypeSelectHeading"]  = "\$text = 'Medientyp wählen';";
 $trans["biblioNewFormLabel"]       = "\$text = 'Neues hinzufügen';";
 $trans["biblioNewSuccess"]         = "\$text = 'Das folgende neue Medium wurde erstellt. Um ein Exemplar hinzuzufügen, wähle \"Neues Exemplar\" aus dem linken Navigationsbereich oder \"Füge neues Exemplar hinzu\" aus der untenstehenden Information.';";
 

--- a/locale/en/cataloging.php
+++ b/locale/en/cataloging.php
@@ -78,6 +78,7 @@ $trans["PictDesc"] = "\$text = 'Image files must be located in the openbiblio/pi
 # ****************************************************************************
 # * Translation text for page biblio_new.php
 # ****************************************************************************
+$trans["biblioTypeSelectHeading"] = "\$text = 'Select Media Type';";
 $trans["biblioNewFormLabel"] = "\$text = 'Add New';";
 $trans["biblioNewSuccess"] = "\$text = 'The following new bibliography has been created.  To add a copy, select \"New Copy\" from the left hand navigation or \"Add New Copy\" from the copy information below.';";
 

--- a/shared/sidebar.php
+++ b/shared/sidebar.php
@@ -254,7 +254,7 @@ $menu_items = [
             ],
             [
                 'title' => $navLoc->getText("catalogBibNew"),
-                'url' => '../catalog/biblio_new.php',
+                'url' => '../catalog/biblio_type_select.php',
                 'icon' => 'fas fa-circle'
             ],
             [


### PR DESCRIPTION
Closes: #124 

## Summary

Adds a visual landing page (`biblio_type_select.php`) that displays all configured material types as clickable icon cards before the new catalog record form. This reduces mis-cataloging by making the material type selection more prominent and intuitive.

## Changes

### New Files
- **`catalog/biblio_type_select.php`** — Landing page showing material types as clickable cards with icons

### Modified Files
- **`catalog/biblio_new.php`** — Accepts `materialCd` query parameter to pre-select material type
- **`shared/sidebar.php`** — Updates "Add New" link to point to the new type selection page
- **`locale/de/cataloging.php`** — Adds German translation for heading
- **`locale/en/cataloging.php`** — Adds English translation for heading

## Implementation Details

The new landing page:
- Queries all material types from `material_type_dm` table
- Displays each type as a Bootstrap card with icon and description
- Uses responsive grid layout (6 cols on mobile, 2 cols on large screens)
- Cards have hover effects (lift and border highlight)
- Clicking a card navigates to `biblio_new.php?materialCd=XX`

The form page (`biblio_new.php`):
- Checks for `materialCd` query parameter
- Pre-selects the material type if provided
- Dropdown remains available as fallback

## Testing Checklist

- [ ] Landing page displays all configured material types
- [ ] Clicking a type card opens the form with that type pre-selected
- [ ] Direct navigation to `biblio_new.php` still works (dropdown defaults)
- [ ] Form submission works correctly with pre-selected type
- [ ] Responsive layout works on mobile, tablet, and desktop
- [ ] Hover effects work as expected
- [ ] Both English and German translations display correctly
