### PR TITLE
Use HTML5 date picker for membership end date field

### DIFF
--- a/circ/mbr_fields.php
+++ b/circ/mbr_fields.php
@@ -48,7 +48,7 @@ if ($set->_isMbrAccountOnline == TRUE && $mbr->getFileSource() != "mbr_edit_form
 foreach ($customFields as $name => $title) {
        $fields[$title . ':'] = inputField('text', 'custom_' . $name, $mbr->getCustom($name));
 }
-$fields["mbrFldsMbrShip"] = inputField('text', "membershipEnd", (!empty($mbr->getMembershipEnd()) ? $mbr->getMembershipEnd() : '') );
+$fields["mbrFldsMbrShip"] = inputField('date', "membershipEnd", (!empty($mbr->getMembershipEnd()) ? $mbr->getMembershipEnd() : '') );
 $fields["mbrFldsClassify"] = inputField('select', 'classification', $mbr->getClassification(), NULL, $mbrClassifyDm);
 
 ?>

--- a/locale/de/circulation.php
+++ b/locale/de/circulation.php
@@ -75,7 +75,7 @@ $trans["mbrFldsEmail"] = "\$text='E-Mail-Adresse:';";
 $trans["mbrFldsClassify"] = "\$text='Klassifikation:';";
 $trans["mbrFldsGrade"] = "\$text='Schulklasse:';";
 $trans["mbrFldsTeacher"] = "\$text='Klassenlehrer:';";
-$trans["mbrFldsMbrShip"] = "\$text='bezahlt bis (jjjj-mm-dd):';";
+$trans["mbrFldsMbrShip"] = "\$text='bezahlt bis:';";
 $trans["mbrFldsSubmit"] = "\$text='Übermitteln';";
 $trans["mbrFldsCancel"] = "\$text='Abbrechen';";
 $trans["mbrsearchResult"] = "\$text='Ergebnisseiten: ';";

--- a/locale/en/circulation.php
+++ b/locale/en/circulation.php
@@ -75,7 +75,7 @@ $trans["mbrFldsEmail"] = "\$text='Email Address:';";
 $trans["mbrFldsClassify"] = "\$text='Classification:';";
 $trans["mbrFldsGrade"] = "\$text='School Grade:';";
 $trans["mbrFldsTeacher"] = "\$text='School Teacher:';";
-$trans["mbrFldsMbrShip"] = "\$text='Membership Ends (yyyy-mm-dd):';";
+$trans["mbrFldsMbrShip"] = "\$text='Membership Ends:';";
 $trans["mbrFldsSubmit"] = "\$text='Submit';";
 $trans["mbrFldsCancel"] = "\$text='Cancel';";
 $trans["mbrsearchResult"] = "\$text='Result Pages: ';";


### PR DESCRIPTION
Fixes #3 

### Summary

This PR replaces the plain text input for the membership end date field with an HTML5 `<input type="date">`, providing users with a native browser date picker and eliminating the need to manually type dates in ISO format.

### Changes

- **[circ/mbr_fields.php](cci:7://file:///Users/udo.woitek/workspace-private/Openbiblio/circ/mbr_fields.php:0:0-0:0)**: Changed membership end date input type from `'text'` to `'date'`
- **[locale/en/circulation.php](cci:7://file:///Users/udo.woitek/workspace-private/Openbiblio/locale/en/circulation.php:0:0-0:0)**: Removed format hint `(yyyy-mm-dd)` from field label
- **[locale/de/circulation.php](cci:7://file:///Users/udo.woitek/workspace-private/Openbiblio/locale/de/circulation.php:0:0-0:0)**: Removed format hint `(jjjj-mm-dd)` from field label

### Benefits

- **Improved UX**: Users get a visual date picker instead of having to remember the ISO date format
- **Reduced errors**: Eliminates format typos and invalid date entries
- **Browser native**: Uses standard HTML5 functionality, no additional dependencies required
- **Minimal change**: Single-line modification to the input type, leveraging existing [inputField()](cci:1://file:///Users/udo.woitek/workspace-private/Openbiblio/functions/inputFuncs.php:9:0-84:1) function

### Testing

Tested on the new member and edit member forms. The date picker displays correctly and properly handles:
- Empty values (new members)
- Existing dates (editing members)
- Date selection and validation

The HTML5 date input expects and receives dates in `YYYY-MM-DD` format, which matches the MySQL `DATE` column format exactly.